### PR TITLE
Use StringComparison in GetHashCode for string field

### DIFF
--- a/Generators/PrimitiveDescriptorExtensions.cs
+++ b/Generators/PrimitiveDescriptorExtensions.cs
@@ -178,7 +178,7 @@ namespace Liversage.Primitives.Generators
                                     IdentifierName(descriptor.Name),
                                     SingleVariableDesignation(Identifier("value")))),
                             InvocationExpression(IdentifierName("Equals"))
-                            .WithArgumentList(ArgumentList(SingletonSeparatedList(Argument(IdentifierName("value"))))))))
+                                .WithArgumentList(ArgumentList(SingletonSeparatedList(Argument(IdentifierName("value"))))))))
                 .WithSemicolonToken(Token(SyntaxKind.SemicolonToken));
 
         public static MemberDeclarationSyntax GetHashCodeSyntax(this PrimitiveDescriptor descriptor)
@@ -193,19 +193,28 @@ namespace Liversage.Primitives.Generators
                                 IdentifierName("GetHashCode")))))
                 .WithSemicolonToken(Token(SyntaxKind.SemicolonToken));
 
-        public static MemberDeclarationSyntax StringGetHashCodeSyntax(this PrimitiveDescriptor descriptor)
+        public static MemberDeclarationSyntax StringGetHashCodeSyntax(this PrimitiveDescriptor descriptor, StringComparison stringComparison)
             => MethodDeclaration(PredefinedType(Token(SyntaxKind.IntKeyword)), Identifier("GetHashCode"))
                 .WithModifiers(TokenList(Token(SyntaxKind.PublicKeyword), Token(SyntaxKind.OverrideKeyword)))
                 .WithExpressionBody(
                     ArrowExpressionClause(
-                        BinaryExpression(
-                            SyntaxKind.CoalesceExpression,
-                            ConditionalAccessExpression(
+                        ConditionalExpression(
+                            BinaryExpression(
+                                SyntaxKind.NotEqualsExpression,
                                 IdentifierName(descriptor.InnerName),
-                                InvocationExpression(MemberBindingExpression(IdentifierName("GetHashCode")))),
-                            LiteralExpression(
-                                SyntaxKind.NumericLiteralExpression,
-                                Literal(0)))))
+                                LiteralExpression(SyntaxKind.NullLiteralExpression)),
+                            InvocationExpression(
+                                MemberAccessExpression(
+                                    SyntaxKind.SimpleMemberAccessExpression,
+                                    MemberAccessExpression(
+                                        SyntaxKind.SimpleMemberAccessExpression,
+                                        IdentifierName("StringComparer"),
+                                        IdentifierName(stringComparison.ToString())),
+                                    IdentifierName("GetHashCode")))
+                                .WithArgumentList(
+                                    ArgumentList(
+                                        SingletonSeparatedList(Argument(IdentifierName(descriptor.InnerName))))),
+                            LiteralExpression(SyntaxKind.NumericLiteralExpression, Literal(0)))))
                 .WithSemicolonToken(Token(SyntaxKind.SemicolonToken));
 
         public static MemberDeclarationSyntax OperatorEqualsSyntax(this PrimitiveDescriptor descriptor)

--- a/Generators/PrimitiveGenerator.cs
+++ b/Generators/PrimitiveGenerator.cs
@@ -193,7 +193,7 @@ namespace Liversage.Primitives.Generators
                 if (!descriptor.Flags.HasFlag(PrimitiveDescriptorFlags.InnerIsString))
                     yield return descriptor.GetHashCodeSyntax();
                 else
-                    yield return descriptor.StringGetHashCodeSyntax();
+                    yield return descriptor.StringGetHashCodeSyntax(stringComparison);
                 yield return descriptor.OperatorEqualsSyntax();
                 yield return descriptor.OperatorNotEqualsSyntax();
             }

--- a/Samples/Directory.Build.props
+++ b/Samples/Directory.Build.props
@@ -1,0 +1,9 @@
+<Project>
+  <PropertyGroup>
+    <LangVersion>8.0</LangVersion> 
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="Liversage.Primitives" Version="1.1.8-*" />
+  </ItemGroup>
+</Project>

--- a/Samples/EntityFramework/EntityFramework.csproj
+++ b/Samples/EntityFramework/EntityFramework.csproj
@@ -6,7 +6,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Liversage.Primitives" Version="1.1.*-*" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="3.1.8" />
     <PackageReference Include="Microsoft.Extensions.Hosting" Version="3.1.8" />
   </ItemGroup>

--- a/Samples/Samples.sln
+++ b/Samples/Samples.sln
@@ -7,12 +7,13 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Samples", "Samples\Samples.
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{F244994C-5928-4E03-86B6-052CF0B766C2}"
 	ProjectSection(SolutionItems) = preProject
+		Directory.Build.props = Directory.Build.props
 		nuget.config = nuget.config
 	EndProjectSection
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "EntityFramework", "EntityFramework\EntityFramework.csproj", "{4ECB4052-5916-46F9-840A-5A8D92AF7144}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "EntityFramework", "EntityFramework\EntityFramework.csproj", "{4ECB4052-5916-46F9-840A-5A8D92AF7144}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SystemTextJson", "SystemTextJson\SystemTextJson.csproj", "{EC0F7082-AF38-4288-AB33-12AEFE208849}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "SystemTextJson", "SystemTextJson\SystemTextJson.csproj", "{EC0F7082-AF38-4288-AB33-12AEFE208849}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution

--- a/Samples/Samples/BasedOnInt.cs
+++ b/Samples/Samples/BasedOnInt.cs
@@ -1,6 +1,4 @@
 ﻿using Liversage.Primitives;
-using System;
-using System.Globalization;
 
 namespace Samples
 {
@@ -8,16 +6,5 @@ namespace Samples
     public readonly partial struct BasedOnInt
     {
         readonly int id;
-
-        public static bool TryParse(string @string, NumberStyles numberStyles, IFormatProvider formatProvider, out BasedOnInt value)
-        {
-            if (!int.TryParse(@string, numberStyles, formatProvider, out int result))
-            {
-                value = default;
-                return false;
-            }
-            value = new BasedOnInt(result);
-            return true;
-        }
     }
 }

--- a/Samples/Samples/BasedOnNullableInt.cs
+++ b/Samples/Samples/BasedOnNullableInt.cs
@@ -1,6 +1,4 @@
 ﻿using Liversage.Primitives;
-using System;
-using System.Globalization;
 
 namespace Samples
 {
@@ -8,21 +6,5 @@ namespace Samples
     public readonly partial struct BasedOnNullableInt
     {
         readonly int? id;
-
-        public static bool TryParse(string @string, IFormatProvider formatProvider, out BasedOnInt value)
-        {
-            if (string.IsNullOrEmpty(@string))
-            {
-                value = default;
-                return true;
-            }
-            if (!int.TryParse(@string, NumberStyles.Integer, formatProvider, out int result))
-            {
-                value = default;
-                return false;
-            }
-            value = new BasedOnInt(result);
-            return true;
-        }
     }
 }

--- a/Samples/Samples/Program.cs
+++ b/Samples/Samples/Program.cs
@@ -210,6 +210,7 @@ namespace Samples
             var currency1 = Currency.FromString("eur");
             var currency2 = Currency.FromString("EUR");
             Console.WriteLine($"{currency1} == {currency2}: {currency1 == currency2}");
+            Console.WriteLine($"{currency1.GetHashCode()} == {currency2.GetHashCode()}: {currency1.GetHashCode() == currency2.GetHashCode()}");
 
             Console.WriteLine();
         }

--- a/Samples/Samples/Samples.csproj
+++ b/Samples/Samples/Samples.csproj
@@ -5,8 +5,4 @@
     <OutputType>Exe</OutputType>
   </PropertyGroup>
   
-  <ItemGroup>
-    <PackageReference Include="Liversage.Primitives" Version="1.1.*-*" />
-  </ItemGroup>
-
 </Project>

--- a/Samples/SystemTextJson/SystemTextJson.csproj
+++ b/Samples/SystemTextJson/SystemTextJson.csproj
@@ -6,7 +6,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Liversage.Primitives" Version="1.1.*-*" />
     <PackageReference Include="Microsoft.Extensions.Hosting" Version="3.1.8" />
     <PackageReference Include="System.Text.Json" Version="4.7.2" />
   </ItemGroup>


### PR DESCRIPTION
When generating `GetHashCode` for a `string` field the code would not take `StringComparison` into account (and always use `StringComparison.Ordinal`).

Incorrect code:

```csharp
public override int GetHashCode() => field?.GetHashCode() ?? 0;
```

Correct code (where the `StringComparison` property value of the `[Primitive]` attribute determines the actual `StringComparison` being used):

```csharp
public override int GetHashCode() => field != null ? StringComparer.OrdinalIgnoreCase.GetHashCode(field) : 0;
```