### PR TITLE
Fix wrong code generated for comparable feature

### DIFF
--- a/Generators/PrimitiveDescriptorExtensions.cs
+++ b/Generators/PrimitiveDescriptorExtensions.cs
@@ -272,7 +272,10 @@ namespace Liversage.Primitives.Generators
                         InvocationExpression(
                             MemberAccessExpression(
                                 SyntaxKind.SimpleMemberAccessExpression,
-                                IdentifierName("value"),
+                                MemberAccessExpression(
+                                    SyntaxKind.SimpleMemberAccessExpression,
+                                    ThisExpression(),
+                                    IdentifierName(descriptor.InnerName)),
                                 IdentifierName("CompareTo")))
                         .WithArgumentList(
                             ArgumentList(
@@ -281,7 +284,7 @@ namespace Liversage.Primitives.Generators
                                         MemberAccessExpression(
                                             SyntaxKind.SimpleMemberAccessExpression,
                                             IdentifierName("other"),
-                                            IdentifierName("value"))))))))
+                                            IdentifierName(descriptor.InnerName))))))))
                 .WithSemicolonToken(Token(SyntaxKind.SemicolonToken));
 
         public static MemberDeclarationSyntax StringIComparableTCompareToSyntax(this PrimitiveDescriptor descriptor, StringComparison stringComparison)

--- a/Samples/Directory.Build.props
+++ b/Samples/Directory.Build.props
@@ -4,6 +4,6 @@
     <Nullable>enable</Nullable>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Liversage.Primitives" Version="1.1.8-*" />
+    <PackageReference Include="Liversage.Primitives" Version="1.1.10-*" />
   </ItemGroup>
 </Project>

--- a/Samples/Samples/Comparable.cs
+++ b/Samples/Samples/Comparable.cs
@@ -5,6 +5,6 @@ namespace Samples
     [Primitive(Features.Default | Features.Comparable)]
     public readonly partial struct Comparable
     {
-        readonly int value;
+        readonly int other;
     }
 }


### PR DESCRIPTION
Fixes issue where the code generated for `Features.Comparable` was only correct when the field name was `value`.