### PR TITLE
Allow primitive types to declare constants

### DIFF
--- a/Generators/RoslynExtensions.cs
+++ b/Generators/RoslynExtensions.cs
@@ -10,12 +10,15 @@ namespace Liversage.Primitives.Generators
     {
         public static PrimitiveDescriptor? ToPrimitiveDescriptor(this TypeDeclarationSyntax typeDeclaration, SemanticModel semanticModel, IProgress<Diagnostic> progress)
         {
-            if (typeDeclaration.Members.OfType<FieldDeclarationSyntax>().Count(field => !field.Modifiers.Any(SyntaxKind.StaticKeyword)) != 1)
+            static bool FieldPredicate(FieldDeclarationSyntax field) =>
+                !field.Modifiers.Any(SyntaxKind.StaticKeyword) && !field.Modifiers.Any(SyntaxKind.ConstKeyword);
+
+            if (typeDeclaration.Members.OfType<FieldDeclarationSyntax>().Count(FieldPredicate) != 1)
             {
                 progress.Report(Diagnostic.Create(Diagnostics.NotExactlyOneField, typeDeclaration.GetLocation(), typeDeclaration.Identifier.ToString()));
                 return null;
             }
-            var innerField = typeDeclaration.Members.OfType<FieldDeclarationSyntax>().First(field => !field.Modifiers.Any(SyntaxKind.StaticKeyword)).Declaration;
+            var innerField = typeDeclaration.Members.OfType<FieldDeclarationSyntax>().First(FieldPredicate).Declaration;
 
             if (innerField.Variables.Count != 1)
             {

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-© 2020 Martin Liversage
+© 2021 Martin Liversage
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
Roslyn describes constants using `FieldDeclarationSyntax`. The check that there only exists a single field should ignore constants.